### PR TITLE
feat: default responses to xAI Grok

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
-OPENAI_API_KEY=your_api_key_here
+XAI_API_KEY=your_xai_api_key_here
+XAI_BASE_URL=https://api.x.ai/v1
+XAI_MODEL=grok-4.20-0309-non-reasoning

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The system defines all essential layers required in a modern RAG backend:
 
 ### Configuration
 - Central `.env` file (never committed)
-- Defines `OPENAI_API_KEY` and model settings
+- Defines `XAI_API_KEY`, with optional `XAI_BASE_URL` and `XAI_MODEL` overrides
 
 ---
 
@@ -78,9 +78,8 @@ The system is designed as a 3-layer pipeline, optimized for CPU-bound environmen
 - **Robustness**: Includes regex normalization for time formats (24h vs AM/PM) to reduce false positives in grounding checks
 
 ### 4. LLM Layer (External)
-- **Provider**: lazy OpenAI adapter (`gpt-4o-mini`) with a deterministic test fake
+- **Provider**: lazy xAI/Grok adapter with a deterministic test fake
 - **Role**: Synthesizes the retrieved context into a natural, empathetic response
-- **Economics**: Chosen for optimal cost/performance ratio on a startup-scale MVP
 
 ---
 
@@ -128,7 +127,7 @@ uv sync --frozen --extra dev
 
 # 3. Configuration
 cp .env.example .env
-# Edit .env and add your OPENAI_API_KEY
+# Edit .env and add your XAI_API_KEY
 ```
 
 The public baseline intentionally ships no downloaded PDFs, source-derived
@@ -142,11 +141,11 @@ deterministic CC0 fixture quickstart:
 uv run python scripts/fake_quickstart.py
 ```
 
-The optional real-provider canary uses only that synthetic context and is
+The optional Grok/xAI provider canary uses only that synthetic context and is
 manual-only (never run by pull requests or forks):
 
 ```bash
-OPENAI_API_KEY=... uv run python scripts/provider_canary.py
+XAI_API_KEY=... uv run python scripts/provider_canary.py
 ```
 
 It prints only a response digest and citation count. With no key it remains
@@ -187,16 +186,6 @@ For debugging or direct terminal usage:
 ```bash
 python src/respond/generate_response.py "What time does Magic Kingdom open?"
 ```
-
----
-
-## Model Strategy & Economics
-
-We selected `gpt-4o-mini` over larger models (like GPT-4) for this architecture:
-
-1. **Latency Constraints:** The local retrieval pipeline is highly optimized (~20ms). Using a heavier LLM would disproportionately increase the total request time without adding factual value (since facts are retrieved via RAG).
-2. **Cost Efficiency:** ~$0.15 / 1M input tokens. This pricing makes high-volume testing feasible for an MVP budget.
-3. **Performance Parity:** For specific, fact-restricted tasks (like "What time does the park open?"), `mini` performs nearly identically to larger models because the intelligence comes from the fusion of context, not just parameter size.
 
 ---
 

--- a/scripts/provider_canary.py
+++ b/scripts/provider_canary.py
@@ -7,14 +7,14 @@ import hashlib
 import os
 import sys
 
-from src.respond.providers import OpenAIProvider
+from src.respond.providers import XAIProvider
 
 
 def main() -> int:
-    if not os.getenv("OPENAI_API_KEY"):
-        raise SystemExit("OPENAI_API_KEY is required; canary is pending")
+    if not os.getenv("XAI_API_KEY"):
+        raise SystemExit("XAI_API_KEY is required; canary is pending")
     context = "Synthetic fixture: Magic Kingdom opens at 09:00 for this test context."
-    provider = OpenAIProvider()
+    provider = XAIProvider()
     response = provider.generate(question="When does the synthetic fixture say the park opens?", context=context)
     if not response.strip():
         raise SystemExit("provider returned an empty response")

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field
 # Import Core Modules
 from src.validate.grounding_check import check_grounding
 from src.retrieve.contracts import RetrievedChunk, Retriever
-from src.respond.providers import ChatProvider, OpenAIProvider
+from src.respond.providers import ChatProvider, XAIProvider
 from dotenv import load_dotenv
 
 # Load Env
@@ -20,7 +20,7 @@ load_dotenv()
 
 # --- Lazy dependencies ---
 fusion_engine: Retriever | None = None
-provider: ChatProvider = OpenAIProvider()
+provider: ChatProvider = XAIProvider()
 
 
 def get_fusion_engine() -> Retriever:

--- a/src/respond/generate_response.py
+++ b/src/respond/generate_response.py
@@ -11,25 +11,15 @@ Minimal FAANG-quality LLM responder for Orlando Experience RAG.
 import os
 import sys
 import csv
-import time
 from datetime import datetime
 from dotenv import load_dotenv
-from langchain_openai import ChatOpenAI
-from langchain_core.prompts import ChatPromptTemplate
+from src.respond.providers import XAIProvider
 
 # Load API key
 load_dotenv()
-if not os.getenv("OPENAI_API_KEY"):
-    print("Error: OPENAI_API_KEY not found in .env", file=sys.stderr)
+if not os.getenv("XAI_API_KEY"):
+    print("Error: XAI_API_KEY not found in .env", file=sys.stderr)
     sys.exit(1)
-
-# Simple empathetic template
-template = """You are a thoughtful Orlando trip advisor.
-Answer the question using only verified facts. Mirror the user's concern.
-If unsure, say so. Be concise, warm, and human.
-
-Question: {question}
-"""
 
 def main():
     if len(sys.argv) < 2:
@@ -37,11 +27,8 @@ def main():
         sys.exit(1)
 
     question = sys.argv[1]
-    prompt = ChatPromptTemplate.from_template(template)
-    model = ChatOpenAI(model="gpt-4o-mini", temperature=0.3)
-
-    chain = prompt | model
-    response = chain.invoke({"question": question}).content
+    provider = XAIProvider(temperature=0.3)
+    response = provider.generate(question=question, context="")
 
     print(response)
 

--- a/src/respond/providers.py
+++ b/src/respond/providers.py
@@ -1,7 +1,22 @@
 from __future__ import annotations
 
 import os
-from typing import Protocol
+from typing import Any, Protocol
+
+
+XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1"
+XAI_DEFAULT_MODEL = "grok-4.20-0309-non-reasoning"
+
+
+def _response_template():
+    """Build the prompt lazily so importing the provider stays dependency-light."""
+    from langchain_core.prompts import ChatPromptTemplate
+
+    return ChatPromptTemplate.from_template(
+        "You are a thoughtful Orlando trip advisor.\n"
+        "Answer using ONLY verified facts in Context. If unsure, say so.\n\n"
+        "Context:\n{context}\n\nQuestion: {question}\n"
+    )
 
 
 class ChatProvider(Protocol):
@@ -14,7 +29,7 @@ class OpenAIProvider:
     def __init__(self, model_name: str = "gpt-4o-mini", temperature: float = 0.3):
         self.model_name = model_name
         self.temperature = temperature
-        self._model = None
+        self._model: Any | None = None
 
     def generate(self, *, question: str, context: str) -> str:
         if self._model is None:
@@ -23,13 +38,38 @@ class OpenAIProvider:
             from langchain_openai import ChatOpenAI
 
             self._model = ChatOpenAI(model=self.model_name, temperature=self.temperature)
-        from langchain_core.prompts import ChatPromptTemplate
+        template = _response_template()
+        return str((template | self._model).invoke({"question": question, "context": context}).content)
 
-        template = ChatPromptTemplate.from_template(
-            "You are a thoughtful Orlando trip advisor.\n"
-            "Answer using ONLY verified facts in Context. If unsure, say so.\n\n"
-            "Context:\n{context}\n\nQuestion: {question}\n"
-        )
+
+class XAIProvider:
+    """Lazy xAI/Grok adapter using xAI's OpenAI-compatible API."""
+
+    def __init__(
+        self,
+        model_name: str | None = None,
+        temperature: float = 0.3,
+        base_url: str | None = None,
+    ):
+        self.model_name = model_name or os.getenv("XAI_MODEL") or XAI_DEFAULT_MODEL
+        self.temperature = temperature
+        self.base_url = base_url or os.getenv("XAI_BASE_URL") or XAI_DEFAULT_BASE_URL
+        self._model: Any | None = None
+
+    def generate(self, *, question: str, context: str) -> str:
+        if self._model is None:
+            api_key = os.getenv("XAI_API_KEY")
+            if not api_key:
+                raise RuntimeError("XAI_API_KEY is required for Grok response generation")
+            from langchain_openai import ChatOpenAI
+
+            self._model = ChatOpenAI(
+                model=self.model_name,
+                temperature=self.temperature,
+                api_key=api_key,
+                base_url=self.base_url,
+            )
+        template = _response_template()
         return str((template | self._model).invoke({"question": question, "context": context}).content)
 
 

--- a/tests/test_xai_provider.py
+++ b/tests/test_xai_provider.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import runpy
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from src.respond.providers import (
+    XAI_DEFAULT_BASE_URL,
+    XAI_DEFAULT_MODEL,
+    XAIProvider,
+)
+
+
+def test_xai_provider_uses_validated_defaults(monkeypatch):
+    monkeypatch.delenv("XAI_BASE_URL", raising=False)
+    monkeypatch.delenv("XAI_MODEL", raising=False)
+
+    provider = XAIProvider()
+
+    assert provider.base_url == XAI_DEFAULT_BASE_URL
+    assert provider.model_name == XAI_DEFAULT_MODEL
+
+
+def test_api_selects_xai_provider_by_default():
+    from src.api import main
+
+    assert isinstance(main.provider, XAIProvider)
+
+
+def test_xai_provider_reads_base_url_and_model_overrides(monkeypatch):
+    monkeypatch.setenv("XAI_BASE_URL", "https://xai.example.test/v1")
+    monkeypatch.setenv("XAI_MODEL", "grok-test")
+
+    provider = XAIProvider()
+
+    assert provider.base_url == "https://xai.example.test/v1"
+    assert provider.model_name == "grok-test"
+
+
+def test_xai_provider_requires_key_only_when_generating(monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+
+    provider = XAIProvider()
+    assert provider._model is None
+
+    with pytest.raises(RuntimeError, match="XAI_API_KEY"):
+        provider.generate(question="q", context="c")
+
+    assert provider._model is None
+
+
+def test_xai_provider_configures_compatible_client_without_network(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class FakeChatOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    class FakeTemplate:
+        def __or__(self, model):
+            assert model is not None
+            return self
+
+        def invoke(self, _payload):
+            return SimpleNamespace(content="synthetic response")
+
+    class FakePromptTemplate:
+        @classmethod
+        def from_template(cls, _template):
+            return FakeTemplate()
+
+    langchain_openai = ModuleType("langchain_openai")
+    langchain_openai.ChatOpenAI = FakeChatOpenAI  # type: ignore[attr-defined]
+    langchain_core_prompts = ModuleType("langchain_core.prompts")
+    langchain_core_prompts.ChatPromptTemplate = FakePromptTemplate  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "langchain_openai", langchain_openai)
+    monkeypatch.setitem(sys.modules, "langchain_core.prompts", langchain_core_prompts)
+    monkeypatch.setenv("XAI_API_KEY", "test-key-not-a-real-secret")
+    monkeypatch.setenv("XAI_BASE_URL", "https://xai.example.test/v1")
+    monkeypatch.setenv("XAI_MODEL", "grok-test")
+
+    provider = XAIProvider(temperature=0.1)
+
+    assert provider.generate(question="q", context="c") == "synthetic response"
+    assert captured == {
+        "model": "grok-test",
+        "temperature": 0.1,
+        "api_key": "test-key-not-a-real-secret",
+        "base_url": "https://xai.example.test/v1",
+    }
+
+
+def test_provider_canary_is_pending_without_key(monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    script = Path(__file__).resolve().parents[1] / "scripts" / "provider_canary.py"
+
+    with pytest.raises(SystemExit) as raised:
+        runpy.run_path(str(script), run_name="__main__")
+
+    assert raised.value.code == "XAI_API_KEY is required; canary is pending"


### PR DESCRIPTION
## Summary

- add a lazy `XAIProvider` using the xAI OpenAI-compatible endpoint, with `XAI_API_KEY`, `XAI_BASE_URL`, and `XAI_MODEL` configuration
- make xAI/Grok the FastAPI default while preserving `OpenAIProvider` and `FakeProvider` contracts
- adapt the manual provider canary and legacy responder path; successful canary output remains digest/length/citation-count only
- update environment and README guidance to remove obsolete OpenAI model/pricing instructions

## Validation

- `uv run pytest -q` — 13 passed, 1 skipped (optional FAISS integration)
- `uv run python scripts/fake_quickstart.py`
- `uv run ruff check src tests scripts`
- `uv run mypy src tests --ignore-missing-imports --follow-imports=skip`
- wheel/sdist build and clean-environment API import
- real xAI canary intentionally not run; no key is required for CI

Issue: #28
